### PR TITLE
Add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,3 +31,28 @@
 - [ ] 主要依存のバージョン表記と実マニフェストの整合を確認したか。
 - [ ] 既存コードパターン探索と機密情報混入チェックを実施したか。
 - [ ] 報告が global 層のタスク分類（🟢🟡🔴）に準拠しているか。
+
+## Cursor Cloud specific instructions
+
+This is a documentation/configuration repository with no runtime services. The "application" is the set of lint, format, and validation scripts.
+
+### Prerequisites
+
+- Node.js >= 18 (installed via NodeSource)
+- Python 3 with `yamllint` and `check-jsonschema` (pip)
+- npm dependencies (see `package.json` devDependencies)
+
+### Key commands (see README.md for full list)
+
+| Task                   | Command                |
+| ---------------------- | ---------------------- |
+| Lint all               | `npm run lint`         |
+| Auto-fix formatting    | `npm run format`       |
+| Schema validation      | `npm run schema:check` |
+| Agent/skill validation | `npm run agent:check`  |
+
+### Gotchas
+
+- `.claude/settings.json` defines PreToolUse hooks that log to `~/.claude/command_history.log`. The directory `~/.claude/` must exist or all Shell commands will be blocked by the hook. The update script creates it via `mkdir -p /root/.claude`.
+- `npm run schema:check` ends with `; true` so it always exits 0, even when schema errors exist. Pre-existing schema mismatches (MCP config files validated against `ai_profile.schema.json`) are expected.
+- `npm run agent:check` may report pre-existing skill validation failures (e.g., trigger keyword count). These are repo-level issues, not environment issues.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 概要

- `AGENTS.md` に Cursor Cloud 環境向けのセクション (`## Cursor Cloud specific instructions`) を追加。将来の Cloud Agent が開発環境のセットアップ済み状態で正しく動作できるよう、前提条件・主要コマンド・既知の注意点を記載。

## チェックリスト

- [ ] 関連 Issue をリンク済み
- [x] ローカルで Markdown/YAML/JSON lint を実行
- [x] 機密情報が含まれていないことを確認

## リスクと影響範囲

- `AGENTS.md` への追記のみ。既存セクションへの変更なし。

## 補足

- 開発環境セットアップの検証ログ:

[validation_output.log](https://cursor.com/agents/bc-783bd15a-5c9b-4e83-9871-ea940c6fd260/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fvalidation_output.log)

### 検証結果

| Command | Result |
| --- | --- |
| `npm run lint` | OK (pre-existing Prettier warnings on 12 files) |
| `npm run schema:check` | OK (exits 0; pre-existing schema mismatches) |
| `npm run agent:check` | Pre-existing skill validation failures |
| `npm run format` | OK (auto-fixed 244 files, 0 markdownlint errors) |


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-783bd15a-5c9b-4e83-9871-ea940c6fd260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-783bd15a-5c9b-4e83-9871-ea940c6fd260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

